### PR TITLE
readme: correcting import in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ And our script, `example.js`, looks as follows:
 ```javascript
 var fs = require('fs')
 var rehype = require('rehype')
-var section = require('rehype-section')
+var section = require('@agentofuser/rehype-section').default
 
 rehype()
   .data('settings', { fragment: true })


### PR DESCRIPTION
The current readme has a code example with an import that does not conform to the current behaviour - see issue #85 

This corrects the import.